### PR TITLE
fix a bug when reading binary models of multibyte words

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -516,10 +516,10 @@ module.exports = function loadModel( file, callback ) {
 					word = buffer
 						.toString()
 						.split(' ')[0];
-					pos += word.length + 1;
+					pos += Buffer.from(word).byteLength + 1;
 					pos += size * 4;
 
-					off = word.length + 1;
+					off = Buffer.from(word).byteLength + 1;
 					values = new Float32Array( size );
 					for ( i = 0; i < size; i++ ) {
 						values[ i ] = buffer.readFloatLE( off );


### PR DESCRIPTION
Current `readBinary` counts the byte of a word using `word.length`.

This is not accurate when the word contains multibyte characters.  
ex. `"の"` is a 3-byte character but `"の".length` equals 1.  
Thus, when `readBinary` reads a binary model of multibyte words, it calculates the wrong offset  and fails to load the model properly.

To fix this I replaced `word.length` with `Buffer.from(word).byteLength`. After this fix I succeeded to load my Japanese binary model generated by gensim (python).