### PR TITLE
Inform the user when file extension is not handled via `error` in `callback`

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -407,6 +407,8 @@ module.exports = function loadModel( file, callback ) {
 			case 'application/octet-stream':
 				readBinary( file );
 			break;
+			default:
+				callback("Unhandled mime type, rename file extension to either .txt or .bin");
 		}
 	}
 	init( file );


### PR DESCRIPTION
I downloaded a file which used the extension `.vec` for the ASCII vectors instead of `.txt` and it just silently failed, which is not a good user experience.

So this PR will warn the user with a proper error message (that the file extension should be either `.bin` or `.txt`).